### PR TITLE
Solve segfault on connection close from outside

### DIFF
--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -750,8 +750,10 @@ cdef class MSSQLConnection:
         Free resources used by this object.
         """
         log("_mssql.MSSQLConnection.real_close()")
-        if self in connection_object_list:
+        try:
             connection_object_list.remove(self)
+        except ValueError:
+            pass
         self._connected = 0
         self.dbproc = NULL
         PyMem_Free(self.last_msg_proc)

--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -254,7 +254,9 @@ cdef int err_handler(DBPROCESS *dbproc, int severity, int dberr, int oserr,
         mssql_lastmsgstate = &(<MSSQLConnection>conn).last_msg_state
         if DBDEAD(dbproc):
             log("+++ err_handler: dbproc is dead; killing conn...\n")
-            conn.mark_disconnected()
+            # Mark connection disconnected. Disconnected connections are
+            # "collected" at next interaction via cancel() method.
+            conn._connected = 0
         break
 
     if severity > mssql_lastmsgseverity[0]:
@@ -754,20 +756,14 @@ cdef class MSSQLConnection:
             connection_object_list.remove(self)
         except ValueError:
             pass
+        # Mark connection disconnected. Disconnected connections are
+        # "collected" at next interaction via cancel() method.
         self._connected = 0
         self.dbproc = NULL
         PyMem_Free(self.last_msg_proc)
         PyMem_Free(self.last_msg_srv)
         PyMem_Free(self.last_msg_str)
         PyMem_Free(self._charset)
-
-    def mark_disconnected(self):
-        """
-        Mark connection disconnected.
-        Disconnected connections are "collected" at next interaction via "cancel" function.
-        """
-        log("_mssql.MSSQLConnection.mark_disconnected()")
-        self._connected = 0
 
     cdef object convert_db_value(self, BYTE *data, int dbtype, int length):
         log("_mssql.MSSQLConnection.convert_db_value()")

--- a/_mssql.pyx
+++ b/_mssql.pyx
@@ -397,7 +397,7 @@ cdef int db_sqlok(DBPROCESS *dbproc):
     return rtc
 
 cdef void clr_err(MSSQLConnection conn):
-    if conn != None:
+    if conn != None and conn in connection_object_list:
         conn.last_msg_no = 0
         conn.last_msg_severity = 0
         conn.last_msg_state = 0
@@ -743,17 +743,29 @@ cdef class MSSQLConnection:
         with nogil:
             dbclose(self.dbproc)
 
-        self.mark_disconnected()
+        self._real_close()
 
-    def mark_disconnected(self):
-        log("_mssql.MSSQLConnection.mark_disconnected()")
-        self.dbproc = NULL
+    def _real_close(self):
+        """
+        Free resources used by this object.
+        """
+        log("_mssql.MSSQLConnection.real_close()")
+        if self in connection_object_list:
+            connection_object_list.remove(self)
         self._connected = 0
+        self.dbproc = NULL
         PyMem_Free(self.last_msg_proc)
         PyMem_Free(self.last_msg_srv)
         PyMem_Free(self.last_msg_str)
         PyMem_Free(self._charset)
-        connection_object_list.remove(self)
+
+    def mark_disconnected(self):
+        """
+        Mark connection disconnected.
+        Disconnected connections are "collected" at next interaction via "cancel" function.
+        """
+        log("_mssql.MSSQLConnection.mark_disconnected()")
+        self._connected = 0
 
     cdef object convert_db_value(self, BYTE *data, int dbtype, int length):
         log("_mssql.MSSQLConnection.convert_db_value()")


### PR DESCRIPTION
This applies pymssql#412 

It should solve an error when forcibly closing tunneled connection to the database (timeout):
*** Error in `/usr/local/bin/python': free(): corrupted unsorted chunks: 0x000000000f679c70 ***

