### PR TITLE
Fix py38 compatibility

### DIFF
--- a/pymssql_version.h
+++ b/pymssql_version.h
@@ -1,1 +1,1 @@
-#define PYMSSQL_VERSION "2.1.3.exp2"
+#define PYMSSQL_VERSION "2.1.3.exp3"

--- a/setup.py
+++ b/setup.py
@@ -156,8 +156,6 @@ SYSTEM = platform.system()
 
 print("setup.py: platform.system() => %r" % SYSTEM)
 print("setup.py: platform.architecture() => %r" % (platform.architecture(),))
-if SYSTEM == 'Linux':
-    print("setup.py: platform.linux_distribution() => %r" % (platform.linux_distribution(),))
 if SYSTEM != 'Windows':
     print("setup.py: platform.libc_ver() => %r" % (platform.libc_ver(),))
 


### PR DESCRIPTION
linux_distribution is removed from Python 3.8 so the package wouldn't build.